### PR TITLE
Expose raw JSON matrix for consumption by other servers

### DIFF
--- a/src/main/java/com/indeed/proctor/webapp/controllers/ProctorController.java
+++ b/src/main/java/com/indeed/proctor/webapp/controllers/ProctorController.java
@@ -109,6 +109,14 @@ public class ProctorController extends AbstractController {
         model.addAttribute("emptyClients", specificationSource.loadAllSpecifications(determineEnvironmentFromParameter(branch)).keySet().isEmpty());
         return getArtifactForView(model, which, View.MATRIX_LIST);
     }
+    
+    @RequestMapping(value="/matrix/raw", method=RequestMethod.GET)
+    public JsonView viewRawTestMatrix(final String branch, final Model model) {
+        final Environment which = determineEnvironmentFromParameter(branch);
+        final TestMatrixVersion testMatrixVersion = getCurrentMatrix(which);
+        final TestMatrixArtifact testMatrixArtifact = ProctorUtils.convertToConsumableArtifact(testMatrixVersion);
+        return new JsonView(testMatrixArtifact);
+    }
 
     @RequestMapping(value="/usage", method=RequestMethod.GET)
     public String viewMatrixUsage(final Model model) {


### PR DESCRIPTION
This is meant to be used with clients implementing UrlProctorLoaders.

(More specifically, along with https://github.com/indeedeng/proctor-pipet/pull/1, this allows webapp+pipet to work together to expose proctor test bucketing to non-Java servers)
